### PR TITLE
feat: add test targets for automated ui flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,31 @@ Eliminar logs `[register]`, `[login]` al cerrar desarrollo.
 - Componente de alerta reutilizable.
 - Paginación.
 - Dark mode.
+
+## Preparar pruebas automatizadas
+
+El frontend expone identificadores (`testID`) estables para que puedas localizar elementos clave desde Cypress/Selenium sin depender de estilos o textos. Algunos ejemplos:
+
+| Flujo | Elemento | testID |
+|-------|----------|--------|
+| Login | Input de email | `login-email` |
+| Login | Botón enviar | `login-submit` |
+| Registro | Input de contraseña | `register-password` |
+| Registro | Mensaje de error API | `register-error-box` |
+| Nueva denuncia | Selector de categoría | `new-report-open-category` |
+| Nueva denuncia | Botón enviar | `new-report-submit` |
+| Tabs autenticadas | Inicio/Nueva denuncia/etc. | `tab-home`, `tab-new-report`, ... |
+
+Pasos sugeridos para automatizar:
+
+1. Instala Cypress como devDependency y añade scripts:
+   ```bash
+   npm install --save-dev cypress @testing-library/cypress
+   npx cypress open
+   ```
+   O bien usa Selenium/WebdriverIO si tu pipeline ya lo soporta.
+2. Levanta el front en modo web (`npm run web`) y apunta tus pruebas a `http://localhost:19006`.
+3. Stubbea las llamadas a la API con `cy.intercept` o herramientas equivalentes. Los servicios consumen endpoints bajo `EXPO_PUBLIC_API_BASE` (`/usuarios/*`, `/denuncias/*`, `/categorias`).
+4. Para la API crea una colección Postman/Newman con los endpoints listados en la sección anterior y orquesta la ejecución con `newman run` dentro de tu CI.
+
+> Nota: Los `testID` de React Native se traducen automáticamente a `data-testid` en la versión web, por lo que podrás seleccionarlos desde Cypress usando `cy.findByTestId('login-submit')`.

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -37,7 +37,12 @@ function LogoutButton({ onLogout }: { onLogout: () => void }) {
   }, [onLogout]);
 
   return (
-    <TouchableOpacity onPress={handlePress} style={{ marginRight: 12 }}>
+    <TouchableOpacity
+      onPress={handlePress}
+      style={{ marginRight: 12 }}
+      testID="logout-button"
+      accessibilityRole="button"
+    >
       <Text style={{ color: '#EF4444', fontWeight: '600' }}>Cerrar sesión</Text>
     </TouchableOpacity>
   );
@@ -72,11 +77,31 @@ function MainTabs({ onLogout }: { onLogout: () => void }) {
         },
       })}
     >
-      <Tab.Screen name="Inicio" component={Home} />
-  <Tab.Screen name="Nueva denuncia" component={NewReport} />
-  <Tab.Screen name="Mis denuncias" component={MyReports} />
-      <Tab.Screen name="Ranking" component={Ranking} />
-      <Tab.Screen name="Perfil" component={Profile} />
+      <Tab.Screen
+        name="Inicio"
+        component={Home}
+        options={{ tabBarTestID: 'tab-home', tabBarAccessibilityLabel: 'Ir a Inicio' }}
+      />
+      <Tab.Screen
+        name="Nueva denuncia"
+        component={NewReport}
+        options={{ tabBarTestID: 'tab-new-report', tabBarAccessibilityLabel: 'Ir a Nueva denuncia' }}
+      />
+      <Tab.Screen
+        name="Mis denuncias"
+        component={MyReports}
+        options={{ tabBarTestID: 'tab-my-reports', tabBarAccessibilityLabel: 'Ir a Mis denuncias' }}
+      />
+      <Tab.Screen
+        name="Ranking"
+        component={Ranking}
+        options={{ tabBarTestID: 'tab-ranking', tabBarAccessibilityLabel: 'Ir a Ranking' }}
+      />
+      <Tab.Screen
+        name="Perfil"
+        component={Profile}
+        options={{ tabBarTestID: 'tab-profile', tabBarAccessibilityLabel: 'Ir a Perfil' }}
+      />
     </Tab.Navigator>
   );
 }

--- a/src/screens/login.tsx
+++ b/src/screens/login.tsx
@@ -108,7 +108,7 @@ const LoginScreen: React.FC<LoginScreenProps> = ({ navigation, onLogin, onForgot
   };
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} testID="login-screen">
       <KeyboardAvoidingView
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         style={styles.keyboardAvoidingView}
@@ -136,6 +136,8 @@ const LoginScreen: React.FC<LoginScreenProps> = ({ navigation, onLogin, onForgot
                 autoCorrect={false}
                 editable={!isLoading}
                 maxLength={100}
+                testID="login-email"
+                accessibilityLabel="Campo de correo"
               />
               {errors.email && <Text style={styles.errorText}>{errors.email}</Text>}
             </View>
@@ -155,11 +157,15 @@ const LoginScreen: React.FC<LoginScreenProps> = ({ navigation, onLogin, onForgot
                   autoCorrect={false}
                   editable={!isLoading}
                   maxLength={50}
+                  testID="login-password"
+                  accessibilityLabel="Campo de contraseña"
                 />
                 <TouchableOpacity
                   onPress={() => setShowPassword(prev=>!prev)}
                   style={{ marginLeft:8, width:64, alignItems:'center' }}
                   disabled={isLoading}
+                  testID="login-toggle-password"
+                  accessibilityRole="button"
                 >
                   <Text style={{ fontSize:14, color:'#3B82F6', fontWeight:'500' }}>
                     {showPassword ? 'Ocultar' : 'Mostrar'}
@@ -177,6 +183,8 @@ const LoginScreen: React.FC<LoginScreenProps> = ({ navigation, onLogin, onForgot
               ]}
               onPress={handleLogin}
               disabled={isLoading}
+              testID="login-submit"
+              accessibilityRole="button"
             >
               <Text style={styles.loginButtonText}>
                 {isLoading ? 'Iniciando...' : 'Iniciar Sesión'}
@@ -184,7 +192,7 @@ const LoginScreen: React.FC<LoginScreenProps> = ({ navigation, onLogin, onForgot
             </TouchableOpacity>
 
             {authError ? (
-              <View style={styles.inlineErrorBox}>
+              <View style={styles.inlineErrorBox} testID="login-error-box">
                 <Text style={styles.inlineErrorIcon}>❌</Text>
                 <Text style={styles.inlineErrorText}>{authError}</Text>
               </View>
@@ -195,6 +203,8 @@ const LoginScreen: React.FC<LoginScreenProps> = ({ navigation, onLogin, onForgot
               style={styles.forgotPasswordContainer}
               onPress={handleForgotPassword}
               disabled={isLoading}
+              testID="login-forgot-password"
+              accessibilityRole="button"
             >
               <Text style={styles.forgotPasswordText}>
                 ¿Olvidaste tu contraseña?
@@ -207,6 +217,8 @@ const LoginScreen: React.FC<LoginScreenProps> = ({ navigation, onLogin, onForgot
               <TouchableOpacity
                 onPress={handleGoToRegister}
                 disabled={isLoading}
+                testID="login-go-to-register"
+                accessibilityRole="button"
               >
                 <Text style={styles.registerLinkButton}>Regístrate</Text>
               </TouchableOpacity>

--- a/src/screens/newReports.tsx
+++ b/src/screens/newReports.tsx
@@ -122,6 +122,8 @@ const NewReportScreen: React.FC<NewReportScreenProps> = ({
         style={[styles.selector, errorCategory && styles.selectorError]}
         onPress={() => openSelector('category')}
         disabled={sending}
+        testID="new-report-open-category"
+        accessibilityRole="button"
       >
         <Text style={[styles.selectorText, !categoryId && styles.selectorPlaceholder]}>
           {categoryId ? getSelectedLabel('category', categoryId) : 'Selecciona categoría'}
@@ -129,7 +131,10 @@ const NewReportScreen: React.FC<NewReportScreenProps> = ({
         <Text style={styles.selectorArrow}>▼</Text>
       </TouchableOpacity>
       {errorCategory ? (
-        <View style={[styles.inlineErrorBox, styles.inlineErrorCentered]}>
+        <View
+          style={[styles.inlineErrorBox, styles.inlineErrorCentered]}
+          testID="new-report-category-error"
+        >
           <Text style={[styles.inlineErrorText, styles.inlineErrorTextCentered]}>{errorCategory}</Text>
         </View>
       ) : null}
@@ -241,6 +246,8 @@ const NewReportScreen: React.FC<NewReportScreenProps> = ({
     <TouchableOpacity
       style={styles.selectorItem}
       onPress={() => handleSelectorSelect(item.id)}
+      testID={`new-report-option-${currentSelector}-${item.id}`}
+      accessibilityRole="button"
     >
       <Text style={styles.selectorItemIcon}>{item.icon || '📁'}</Text>
       <View style={{ flex: 1 }}>
@@ -253,7 +260,7 @@ const NewReportScreen: React.FC<NewReportScreenProps> = ({
   );
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} testID="new-report-screen">
       <ScreenHeader title="SpeakUp" variant="brand">
         <Text style={styles.headerSubtitle}>Nueva denuncia</Text>
       </ScreenHeader>
@@ -273,7 +280,7 @@ const NewReportScreen: React.FC<NewReportScreenProps> = ({
           keyboardShouldPersistTaps="handled"
         >
           {/* Warning Message */}
-          <View style={styles.warningContainer}>
+          <View style={styles.warningContainer} testID="new-report-privacy-reminder">
             <Text style={styles.warningIcon}>🔐</Text>
             <Text style={styles.warningText}>
               No se guardarán tus datos personales
@@ -295,6 +302,8 @@ const NewReportScreen: React.FC<NewReportScreenProps> = ({
                 value={title}
                 onChangeText={setTitle}
                 editable={!sending}
+                testID="new-report-title"
+                accessibilityLabel="Campo de título de la denuncia"
               />
             </View>
 
@@ -315,6 +324,8 @@ const NewReportScreen: React.FC<NewReportScreenProps> = ({
                 textAlignVertical="top"
                 editable={!sending}
                 maxLength={500}
+                testID="new-report-description"
+                accessibilityLabel="Campo de descripción de la denuncia"
               />
               <Text style={styles.characterCount}>
                 {description.length}/500 caracteres
@@ -334,6 +345,8 @@ const NewReportScreen: React.FC<NewReportScreenProps> = ({
                 style={styles.selector}
                 onPress={() => openSelector('location')}
                 disabled={sending}
+                testID="new-report-open-location"
+                accessibilityRole="button"
               >
                 <Text style={[
                   styles.selectorText,
@@ -363,6 +376,9 @@ const NewReportScreen: React.FC<NewReportScreenProps> = ({
                         idx === severities.length - 1 && { marginRight: 0 },
                         active && { backgroundColor: s.bg, borderColor: s.color }
                       ]}
+                      testID={`new-report-severity-${s.id}`}
+                      accessibilityRole="button"
+                      accessibilityState={{ selected: active }}
                     >
                       <Text style={[styles.severityButtonText, active && { color: s.color }]}>
                         {s.label}
@@ -375,12 +391,18 @@ const NewReportScreen: React.FC<NewReportScreenProps> = ({
 
             {/* Error/Success Message */}
             {error ? (
-              <View style={[styles.inlineErrorBox, styles.inlineErrorCentered]}>
+              <View
+                style={[styles.inlineErrorBox, styles.inlineErrorCentered]}
+                testID="new-report-error-box"
+              >
                 <Text style={[styles.inlineErrorText, styles.inlineErrorTextCentered]}>{error}</Text>
               </View>
             ) : null}
             {success ? (
-              <View style={[styles.inlineSuccessBox, styles.inlineErrorCentered]}>
+              <View
+                style={[styles.inlineSuccessBox, styles.inlineErrorCentered]}
+                testID="new-report-success-box"
+              >
                 <Text style={[styles.inlineSuccessText, styles.inlineErrorTextCentered]}>{success}</Text>
               </View>
             ) : null}
@@ -393,6 +415,8 @@ const NewReportScreen: React.FC<NewReportScreenProps> = ({
               ]}
               onPress={handleSubmit}
               disabled={sending}
+              testID="new-report-submit"
+              accessibilityRole="button"
             >
               <Text style={styles.submitButtonText}>
                 {sending ? 'Enviando...' : 'Crear denuncia'}
@@ -416,6 +440,8 @@ const NewReportScreen: React.FC<NewReportScreenProps> = ({
               <TouchableOpacity
                 style={styles.modalCloseButton}
                 onPress={() => setShowSelector(false)}
+                testID="new-report-close-selector"
+                accessibilityRole="button"
               >
                 <Text style={styles.modalCloseText}>✕</Text>
               </TouchableOpacity>

--- a/src/screens/register.tsx
+++ b/src/screens/register.tsx
@@ -104,7 +104,7 @@ const RegisterScreen: React.FC = () => {
   };
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} testID="register-screen">
       <KeyboardAvoidingView
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         style={styles.keyboardAvoidingView}
@@ -137,6 +137,8 @@ const RegisterScreen: React.FC = () => {
                 autoCorrect={false}
                 editable={!isLoading && !showSuccess}
                 maxLength={20}
+                testID="register-username"
+                accessibilityLabel="Campo de nombre de usuario"
               />
               <Text style={styles.inputHelper}>
                 Mínimo 3 caracteres, máximo 20
@@ -158,6 +160,8 @@ const RegisterScreen: React.FC = () => {
                 editable={!isLoading && !showSuccess}
                 keyboardType="email-address"
                 maxLength={50}
+                testID="register-email"
+                accessibilityLabel="Campo de correo"
               />
               {errors.email ? (
                 <Text style={styles.errorText}>{errors.email}</Text>
@@ -177,10 +181,14 @@ const RegisterScreen: React.FC = () => {
                   autoCorrect={false}
                   editable={!isLoading && !showSuccess}
                   maxLength={50}
+                  testID="register-password"
+                  accessibilityLabel="Campo de contraseña"
                 />
                 <TouchableOpacity
                   onPress={() => setShowPassword(!showPassword)}
                   style={{ marginLeft: 8, width: 60, alignItems: 'center' }}
+                  testID="register-toggle-password"
+                  accessibilityRole="button"
                 >
                   <Text style={{ fontSize: 14, color: '#3B82F6', fontWeight: '500' }}>
                     {showPassword ? 'Ocultar' : 'Mostrar'}
@@ -208,10 +216,14 @@ const RegisterScreen: React.FC = () => {
                   autoCorrect={false}
                   editable={!isLoading && !showSuccess}
                   maxLength={50}
+                  testID="register-confirm-password"
+                  accessibilityLabel="Campo de confirmación de contraseña"
                 />
                 <TouchableOpacity
                   onPress={() => setShowConfirmPassword(!showConfirmPassword)}
                   style={{ marginLeft: 8, width: 60, alignItems: 'center' }}
+                  testID="register-toggle-confirm-password"
+                  accessibilityRole="button"
                 >
                   <Text style={{ fontSize: 14, color: '#3B82F6', fontWeight: '500' }}>
                     {showConfirmPassword ? 'Ocultar' : 'Mostrar'}
@@ -224,7 +236,7 @@ const RegisterScreen: React.FC = () => {
             </View>
 
             {apiError ? (
-              <View style={styles.inlineErrorBox}>
+              <View style={styles.inlineErrorBox} testID="register-error-box">
                 <Text style={styles.inlineErrorIcon}>❌</Text>
                 <Text style={styles.inlineErrorText}>{apiError}</Text>
               </View>
@@ -232,7 +244,7 @@ const RegisterScreen: React.FC = () => {
 
             {showSuccess && (
               <>
-                <View style={styles.successContainer}>
+                <View style={styles.successContainer} testID="register-success-box">
                   <Text style={styles.successTitle}>¡Registro exitoso!</Text>
                   <Text style={styles.successText}>Tu cuenta ha sido creada correctamente.</Text>
                 </View>
@@ -249,6 +261,8 @@ const RegisterScreen: React.FC = () => {
               ]}
               onPress={handleRegister}
               disabled={isLoading || showSuccess}
+              testID="register-submit"
+              accessibilityRole="button"
             >
               <Text style={styles.registerButtonText}>
                 {isLoading ? 'Registrando...' : 'Registrarse'}
@@ -257,7 +271,11 @@ const RegisterScreen: React.FC = () => {
 
             <View style={styles.loginLinkContainer}>
               <Text style={styles.loginLinkText}>¿Ya tienes una cuenta? </Text>
-              <TouchableOpacity onPress={() => navigation.navigate('Login' as never)}>
+              <TouchableOpacity
+                onPress={() => navigation.navigate('Login' as never)}
+                testID="register-go-to-login"
+                accessibilityRole="button"
+              >
                 <Text style={styles.loginLinkButton}>Inicia sesión</Text>
               </TouchableOpacity>
             </View>


### PR DESCRIPTION
## Summary
- add stable testIDs to login, register, and new report screens to simplify UI automation
- expose tabBar test IDs and logout button identifier for Cypress/Selenium selectors
- document the available selectors and automation setup steps in the README

## Testing
- npm run lint *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_e_68cee3ff963c832493c48b52ec313958